### PR TITLE
docs: fix internal links (dead-link check)

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -41,13 +41,13 @@ Each layer in the stack has a distinct and well-defined set of responsibilities.
 
 ### 2.1 Ledger-Kernel (Specification + Model)
 
-This foundational layer defines the axiomatic properties of the system. Here, we define the abstract rules that must always be true for a ledger to be considered valid. Its responsibilities include defining the **semantic and mathematical invariants** (see [`SPEC.md`](./SPEC.md), and [`MODEL.md`](./MODEL.md)), specifying the canonical reference layout and data schemas, and provide the compliance suite and defining all proof obligations for implementations.
+This foundational layer defines the axiomatic properties of the system. Here, we define the abstract rules that must always be true for a ledger to be considered valid. Its responsibilities include defining the **semantic and mathematical invariants** (see [`SPEC`](../spec/), and [`MODEL`](../model/)), specifying the canonical reference layout and data schemas, and provide the compliance suite and defining all proof obligations for implementations.
 
 ### 2.2 `libgitledger` (Core Runtime)
 
 This layer is the core runtime, a concrete and portable C implementation of the abstract specification. It implements the logic for Git object creation, reference management, and invariant validation.
 
-Its role is to expose the canonical, language-neutral Reference API (see [`REFERENCE.md`](./REFERENCE.md)).
+Its role is to expose the canonical, language-neutral Reference API (see [`Reference API`](../reference/)).
 
 > [!tip] What if AI could generate and emit compliance proofs for every mutating operation?
 

--- a/docs/compliance/index.md
+++ b/docs/compliance/index.md
@@ -11,7 +11,7 @@ Version: 0.1.0
 
 ## 1. Purpose
 
-The compliance suite ensures that any implementation of the **Ledger-Kernel** (e.g., `libgitledger`, `ledger-core-rust`, `ledger-js`) adheres to the invariants, semantics, and deterministic behavior defined in [`SPEC.md`](./SPEC.md) and [`MODEL.md`](./MODEL.md).
+The compliance suite ensures that any implementation of the **Ledger-Kernel** (e.g., `libgitledger`, `ledger-core-rust`, `ledger-js`) adheres to the invariants, semantics, and deterministic behavior defined in [`SPEC`](../spec/) and [`MODEL`](../model/).
 
 A compliant implementation must **pass all mandatory tests** and **expose proofs or logs**
 demonstrating correctness.

--- a/docs/implementation/index.md
+++ b/docs/implementation/index.md
@@ -12,7 +12,7 @@ Version: 0.1.0
 
 ## Abstract
 
-This paper presents `libgitledger`, a portable C reference implementation of a verifiable, append‑only ledger that operates natively within a standard Git repository. The library instantiates the formal model described in [`MODEL.md`](./MODEL.md) and adheres to the invariants set forth in [`SPEC.md`](./SPEC.md) by constraining a designated Git reference to fast‑forward only evolution, serializing entries using a canonical JSON encoding, and binding those entries to cryptographic attestations.
+This paper presents `libgitledger`, a portable C reference implementation of a verifiable, append‑only ledger that operates natively within a standard Git repository. The library instantiates the formal model described in [`MODEL`](../model/) and adheres to the invariants set forth in [`SPEC`](../spec/) by constraining a designated Git reference to fast‑forward only evolution, serializing entries using a canonical JSON encoding, and binding those entries to cryptographic attestations.
 
 Policy compliance is enforced through a deterministic evaluation interface that admits both native predicates and an optional, fuel‑metered WebAssembly policy engine.
 
@@ -24,7 +24,7 @@ We describe the system architecture, data paths for append, replay, and verify o
 
 ## 1. Introduction
 
-Git’s content‑addressed object model, together with its global reference namespace, furnishes a robust foundation for provenance. Yet, its affordances for branching and history rewriting introduce ambiguity for applications that require a totally ordered, non‑repudiable history. `libgitledger` reconciles this tension by erecting a deterministic state machine on top of a constrained Git reference whose history evolves exclusively via fast‑forward commits. Each commit encodes a single ledger entry, and the entire sequence forms a pure, replayable computation whose output state is uniquely determined by the ordered set of entries. This paper explains how the implementation realizes that model and exposes a minimal, language‑agnostic API compatible with [`REFERENCE.md`](./REFERENCE.md).
+Git’s content‑addressed object model, together with its global reference namespace, furnishes a robust foundation for provenance. Yet, its affordances for branching and history rewriting introduce ambiguity for applications that require a totally ordered, non‑repudiable history. `libgitledger` reconciles this tension by erecting a deterministic state machine on top of a constrained Git reference whose history evolves exclusively via fast‑forward commits. Each commit encodes a single ledger entry, and the entire sequence forms a pure, replayable computation whose output state is uniquely determined by the ordered set of entries. This paper explains how the implementation realizes that model and exposes a minimal, language‑agnostic API compatible with the [`Reference API`](../reference/).
 
 The overarching design thesis is that **a ledger should be a conservative extension of infrastructure developers already trust**. By forming the kernel using Git, a well-trusted, battle-worn powerhouse, without introducing bespoke storage or a privileged daemon, `libgitledger` inherits well‑understood operational semantics while adding determinism, cryptographic attestation, and verifiable policy enforcement. The result is a compact, auditable implementation that can be linked into a wide range of host systems.
 
@@ -227,7 +227,7 @@ The evaluation of `libgitledger` rests on three pillars.
 
 **Unit tests** validate that entry serialization round‑trips faithfully and that computed hashes are invariant under platform variation, including differences in endianness and C library implementations.
 
-**Compliance tests** mirror [`COMPLIANCE.md`](./COMPLIANCE.md) and [`SPEC.md`](./SPEC.md), asserting fast‑forward enforcement, policy gate correctness, attestation verification, and replay purity against a suite of golden repositories.
+**Compliance tests** mirror the [`COMPLIANCE`](../compliance/) and [`SPEC`](../spec/) documents, asserting fast‑forward enforcement, policy gate correctness, attestation verification, and replay purity against a suite of golden repositories.
 
 **Property‑based and fuzz testing** generate randomized sequences of valid and invalid entries to probe invariants and ensure that rejection cases are classified precisely.
 


### PR DESCRIPTION
Fixes VitePress dead links by changing section cross-references to site-relative paths.\n\n- Architecture: SPEC/MODEL/REFERENCE links\n- Compliance: SPEC/MODEL links\n- Implementation: MODEL/SPEC/REFERENCE/COMPLIANCE links\n\nThis should make the CI VitePress build pass again.